### PR TITLE
Req 09 - Restrict Public Access to Course Listings changes done

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -339,10 +339,10 @@ FEATURES = {
     'ENABLE_XBLOCK_XML_VALIDATION': True,
 
     # Allow public account creation
-    'ALLOW_PUBLIC_ACCOUNT_CREATION': True,
+    'ALLOW_PUBLIC_ACCOUNT_CREATION': False,
 
     # Allow showing the registration links
-    'SHOW_REGISTRATION_LINKS': True,
+    'SHOW_REGISTRATION_LINKS': False,
 
     # Whether or not the dynamic EnrollmentTrackUserPartition should be registered.
     'ENABLE_ENROLLMENT_TRACK_USER_PARTITION': True,

--- a/lms/djangoapps/branding/views.py
+++ b/lms/djangoapps/branding/views.py
@@ -43,6 +43,10 @@ def index(request):
                 'ALWAYS_REDIRECT_HOMEPAGE_TO_DASHBOARD_FOR_AUTHENTICATED_USER',
                 settings.FEATURES.get('ALWAYS_REDIRECT_HOMEPAGE_TO_DASHBOARD_FOR_AUTHENTICATED_USER', True)):
             return redirect('dashboard')
+    else:
+        # Redirect unauthenticated users to the login page
+        login_url = f"/login{login_query()}"
+        return redirect(login_url)
 
     enable_mktg_site = configuration_helpers.get_value(
         'ENABLE_MKTG_SITE',
@@ -77,6 +81,10 @@ def index(request):
             f'Request Meta= {request.META}'
         )
         raise
+
+def login_query():
+    # Implement your login query logic here
+    return "?next=/"
 
 
 @ensure_csrf_cookie

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -762,7 +762,7 @@ FEATURES = {
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2017-04-12
     # .. toggle_tickets: https://openedx.atlassian.net/browse/YONK-513
-    'ALLOW_PUBLIC_ACCOUNT_CREATION': True,
+    'ALLOW_PUBLIC_ACCOUNT_CREATION': False,
 
     # .. toggle_name: FEATURES['SHOW_REGISTRATION_LINKS']
     # .. toggle_implementation: DjangoSetting
@@ -771,7 +771,7 @@ FEATURES = {
     #   the signup page.
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2023-03-27
-    'SHOW_REGISTRATION_LINKS': True,
+    'SHOW_REGISTRATION_LINKS': False,
 
     # .. toggle_name: FEATURES['ENABLE_COOKIE_CONSENT']
     # .. toggle_implementation: DjangoSetting


### PR DESCRIPTION
### Description

This PR addresses the following updates to enhance the platform's security and user navigation:

- **Restrict Public Access**: The course listing page is now restricted to ensure only invited or pre-created user accounts can access this content.
- **Homepage Redirect**: The homepage defaults to the sign-in page for all users, redirecting unauthenticated users.
- **Register Button Removal**: The "Register" button has been removed across the platform, including on the logout screen, to streamline the user experience.

#### How Has This Been Tested?

- Verified that unauthenticated users are redirected to the sign-in page when accessing restricted areas or the homepage.
- Confirmed that only invited or pre-created user accounts can access the course listing page.
- Tested the removal of the "Register" button across the platform, including the logout screen.

#### JIRA

[[LMS-94](https://kernernorland.atlassian.net/browse/LMS-94?atlOrigin=eyJpIjoiOTlmYmZjMWJlMGNhNGJjZGFlYWZhYzU0OTg0ODk1OTciLCJwIjoiaiJ9)